### PR TITLE
Create 학과별_전임교원_기준연도기반정렬_전처리_템플릿.ipynb

### DIFF
--- a/HSnotebook/중간 보고 이후 2차 전처리 템플릿/학과별_전임교원_기준연도기반정렬_전처리_템플릿.ipynb
+++ b/HSnotebook/중간 보고 이후 2차 전처리 템플릿/학과별_전임교원_기준연도기반정렬_전처리_템플릿.ipynb
@@ -1,0 +1,100 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "971e659a",
+   "metadata": {},
+   "source": [
+    "파일 : 혁진씨 계열별 전처리 파일 : 학과별_전임교원.csv 파일 사용\n",
+    "전처리 사항\n",
+    "1. 기준연도 2024 제거 (2010~2023의 데이터를 학습하는 프로젝트이기 때문)\n",
+    "2. 학생1인당 전임교원 수 계산 : 전임교원수/재학생 수\n",
+    "이유 : 학생입장에서는 같은 수학 지표더라도 더 의미 있을 수 있어서 추가\n",
+    "3. 2010~2023 공통학교 필터링 \n",
+    "3. 기준연도 별로 학교명 오름차순 정렬"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2cc1465f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#  데이터 불러오기\n",
+    "import pandas as pd\n",
+    "\n",
+    "# Colab 좌측 파일탐색기에 업로드한 경우, 파일명만 사용해도 됨\n",
+    "df = pd.read_csv('학과별_전임교원.csv', encoding='utf-8')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "556646aa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#  기준연도 2024 제거\n",
+    "df = df[df['기준연도'] < 2024].copy()\n",
+    "\n",
+    "#  학생1인당 전임교원 수 계산 (재학생 ÷ 전임교원) 후 소수점 첫째 자리 반올림\n",
+    "df['학생1인당전임교원'] = (df['재학생'] / df['전임교원']).round(1)\n",
+    "\n",
+    "#  기준연도 오름차순 정렬\n",
+    "df = df.sort_values(by='기준연도').reset_index(drop=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4e3d7bc7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 공통학교 필터링 및 정렬 (기준연도 → 학교명 순)\n",
+    "# 2023년 기준 학교명 목록 추출\n",
+    "schools_2023 = df[df['기준연도'] == 2023]['학교명'].unique()\n",
+    "\n",
+    "# 전체 연도 데이터에서 2023년도에 존재한 학교만 남김\n",
+    "common_school_df = df[df['학교명'].isin(schools_2023)]\n",
+    "\n",
+    "# 연도별 등장 횟수 계산 (학교명 기준)\n",
+    "year_counts = common_school_df.groupby('학교명')['기준연도'].nunique()\n",
+    "\n",
+    "# 모든 연도(2010~2023: 14년)에 등장한 학교만 필터링\n",
+    "common_schools_all_years = year_counts[year_counts == 14].index\n",
+    "\n",
+    "# 최종 공통학교 데이터셋 생성 후 정렬\n",
+    "df_common = common_school_df[common_school_df['학교명'].isin(common_schools_all_years)].copy()\n",
+    "df_common = df_common.sort_values(by=['기준연도', '학교명']).reset_index(drop=True)\n",
+    "\n",
+    "# 확인\n",
+    "print(f\"공통학교 수: {df_common['학교명'].nunique()}개\")\n",
+    "df_common.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fbf54f80",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ✅ 공통학교 데이터 저장\n",
+    "df_common.to_csv('전처리_완료_공통학교_학과별_전임교원.csv', index=False, encoding='utf-8-sig')\n",
+    "\n",
+    "# Colab 환경에서 직접 다운로드\n",
+    "from google.colab import files\n",
+    "files.download('전처리_완료_공통학교_학과별_전임교원.csv')"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
전처리 사항
1. 기준연도 2024 제거 (2010~2023의 데이터를 학습하는 프로젝트이기 때문)
2. 학생1인당 전임교원 수 계산 : 전임교원수/재학생 수 이유 : 학생입장에서는 같은 수학 지표더라도 더 의미 있을 수 있어서 추가
3. 2010~2023 공통학교 필터링
3. 기준연도 별로 학교명 오름차순 정렬